### PR TITLE
feat: add NOTION_CACHE parser

### DIFF
--- a/src/server/notion.ts
+++ b/src/server/notion.ts
@@ -22,8 +22,23 @@ import {
   getEmbedHtml,
 } from './files'
 
+export const parseNotionCache = (v?: string) => {
+  switch (v) {
+    case '0':
+    case 'n':
+    case 'false':
+      return false
+    case '1':
+    case 'y':
+    case 'true':
+    default:
+      return true
+  }
+}
+
 const cacheDir = process.env.NOTIONATE_CACHEDIR || '.cache'
 const auth = process.env.NOTION_TOKEN
+const cache = parseNotionCache(process.env.NOTION_CACHE)
 const notion = new Client({ auth })
 
 const isEmpty = (obj: Object) => {
@@ -35,7 +50,7 @@ export const FetchDatabase = async (params: QueryDatabaseParameters): Promise<Qu
   const limit = ('page_size' in params) ? params.page_size : undefined
   const paramsHash = atoh(JSON.stringify(params))
 
-  const useCache = process.env.NOTION_CACHE === 'true'
+  const useCache = cache
   if (useCache) {
     await createDirWhenNotfound(cacheDir)
   }
@@ -112,7 +127,7 @@ export const FetchDatabase = async (params: QueryDatabaseParameters): Promise<Qu
 }
 
 export const FetchPage = async (page_id: string): Promise<GetPageResponseEx> => {
-  const useCache = process.env.NOTION_CACHE === 'true'
+  const useCache = cache
   if (useCache) {
     await createDirWhenNotfound(cacheDir)
   }
@@ -177,7 +192,7 @@ export const FetchPage = async (page_id: string): Promise<GetPageResponseEx> => 
 }
 
 export const FetchBlocks = async (block_id: string): Promise<ListBlockChildrenResponseEx> => {
-  const useCache = process.env.NOTION_CACHE === 'true'
+  const useCache = cache
   if (useCache) {
     await createDirWhenNotfound(cacheDir)
   }

--- a/test/server/notion.test.ts
+++ b/test/server/notion.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'uvu'
+import * as td from 'testdouble'
+import * as assert from 'uvu/assert'
+import * as notion from '../../src/server/notion'
+
+test.before(() => {
+  td.reset()
+})
+
+test('parse NOTION_CACHE', async ()=> {
+  const tests: [string | undefined, boolean][] = [
+    [undefined, true],
+    ['0', false],
+    ['1', true],
+    ['true', true],
+    ['false', false],
+    ['y', true],
+    ['n', false],
+  ]
+  for (const [v, ex] of tests) {
+    assert.equal(notion.parseNotionCache(v), ex)
+  }
+})
+
+test.run()


### PR DESCRIPTION
According to the specification, cache is used when "NOTION_CACHE" is true. In practice, cache is not used if the environment variable is undefined.

This PR adds a parser for "NOTION_CACHE" to enable caching when an undefined or generally true string is detected.

Please check the test case for details.